### PR TITLE
Use ets:update_counter/4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{minimum_otp_vsn, "17.0"}.
+{minimum_otp_vsn, "18.0"}.
 
 {deps,
  [

--- a/src/statman_counter.erl
+++ b/src/statman_counter.erl
@@ -60,13 +60,8 @@ incr(Key, Incr) when is_integer(Incr) ->
     %% use multiple keys and try to snapshot a value across all
     %% subkeys. See
     %% https://github.com/boundary/high-scale-lib/blob/master/src/main/java/org/cliffc/high_scale_lib/ConcurrentAutoTable.java
-    case catch ets:update_counter(?TABLE, Key, Incr) of
-        {'EXIT', {badarg, _}} ->
-            (catch ets:insert(?TABLE, {Key, Incr})),
-            ok;
-        _ ->
-            ok
-    end;
+    ets:update_counter(?TABLE, Key, Incr, {Key, 0}),
+    ok;
 
 incr(_Key, Float) when is_float(Float) ->
     error(badarg).

--- a/src/statman_gauge.erl
+++ b/src/statman_gauge.erl
@@ -23,12 +23,13 @@ decr(Key, Decr) -> incr(Key, -Decr).
 
 
 incr(Key, Incr) ->
-    case catch ets:update_counter(?TABLE, Key, {3, Incr}) of
-        {'EXIT', {badarg, _}} ->
-            set(Key, Incr),
-            ok;
+    try ets:update_counter(?TABLE, Key, {3, Incr}) of
         _ ->
             ets:update_element(?TABLE, Key, {2, now_to_seconds()}),
+            ok
+    catch
+        error:badarg ->
+            set(Key, Incr),
             ok
     end.
 

--- a/src/statman_histogram.erl
+++ b/src/statman_histogram.erl
@@ -1,4 +1,4 @@
-%% @doc: Histogram backed by ETS and ets:update_counter/3.
+%% @doc: Histogram backed by ETS and ets:update_counter/4.
 %%
 %% Calculation of statistics is borrowed from basho_stats_histogram
 %% and basho_stats_sample.
@@ -156,13 +156,8 @@ sd(N, Sum, Sum2) ->
 
 
 histogram_incr(Key, Incr) ->
-    case catch ets:update_counter(?TABLE, Key, Incr) of
-        {'EXIT', {badarg, _}} ->
-            (catch ets:insert(?TABLE, {Key, Incr})),
-            ok;
-        _ ->
-            ok
-    end.
+    ets:update_counter(?TABLE, Key, Incr, {Key, 0}),
+    ok.
 
 find_quantile(Freqs, NeededSamples) ->
     find_quantile(Freqs, 0, NeededSamples).


### PR DESCRIPTION
ets:update_counter/4 lets us specify a default object to insert into
an ETS table if the counter we want to increase isn't yet present.  It
was introduced in Erlang/OTP 18.

This means we don't have to catch badarg errors.  Catching an error
with a plain 'catch' is inefficient starting in Erlang/OTP 15; see
http://erlang.org/pipermail/erlang-questions/2013-November/075928.html

Change statman_gauge:incr/2 to use a try/catch around
ets:update_counter/3: in this case we would need to always calculate
the current timestamp in order to pass it as a default object, and I'm
not sure whether that would be a net win.  Let's use a try-catch in
order to not build the stack trace, at least.