### PR TITLE
Remove hipe compilation from transform_histogram

### DIFF
--- a/src/statman_histogram.erl
+++ b/src/statman_histogram.erl
@@ -20,8 +20,6 @@
 -export([bin/1,
          ts/0]).
 
--compile([native]).
-
 -define(TABLE, statman_histograms).
 
 


### PR DESCRIPTION
On Erlang 22.3.3 we observed tenfold perforrmace decrease when running
functions with statman_histogram:run/4. Removing native compilation from
statman solved the problem.

Removing hipe is also future proof as hipe is essentially unmaintained
now.