### PR TITLE
Get decorators dependency from Hex package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,8 +4,9 @@
 
 {deps,
  [
-    {decorators, "",
-         {git, "git://github.com/chrisavl/erlang_decorators.git",
-         {ref, "b14949efc938157604447adc29a71913298fe67f"}}}
+    {decorators, "~> 0.1"},
+    %% parse_trans is used by decorators. Let's ask for a modern version
+    %% to avoid some compiler warnings.
+    {parse_trans, "~> 3.3"}
  ]
 }.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
-[{<<"decorators">>,
-  {git,"git://github.com/chrisavl/erlang_decorators.git",
-       {ref,"b14949efc938157604447adc29a71913298fe67f"}},
-  0},
- {<<"parse_trans">>,
-  {git,"git://github.com/uwiger/parse_trans.git",
-       {ref,"76abb347c3c1d00fb0ccf9e4b43e22b3d2288484"}},
-  1}].
+{"1.1.0",
+[{<<"decorators">>,{pkg,<<"decorators">>,<<"0.1.0">>},0},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.1">>},0}]}.
+[
+{pkg_hash,[
+ {<<"decorators">>, <<"1F4FD3682DE23C6BCE769201613812F5EAF809310A27E35DDBFD91E53B126267">>},
+ {<<"parse_trans">>, <<"16328AB840CC09919BD10DAB29E431DA3AF9E9E7E7E6F0089DD5A2D2820011D8">>}]}
+].


### PR DESCRIPTION
This seems to get rid of the strict dependency on an old parse_trans
version.

Also add parse_trans as a top-level dependency, so we can explicitly
request a newer version.